### PR TITLE
Set first click free URL in request.env

### DIFF
--- a/lib/first_click_free/concerns/controller.rb
+++ b/lib/first_click_free/concerns/controller.rb
@@ -71,11 +71,12 @@ module FirstClickFree
 
         # Has this session already visited?
         if session[:first_click] && session[:first_click] == url_for
+          request.env["first_click_free.url"] = session[:first_click]
           return true
         elsif session[:first_click]
           raise FirstClickFree::Exceptions::SubsequentAccessException
         else
-          session[:first_click] = url_for
+          request.env["first_click_free.url"] = session[:first_click] = url_for
           return true
         end
       end

--- a/spec/concerns/controller_spec.rb
+++ b/spec/concerns/controller_spec.rb
@@ -23,11 +23,13 @@ describe FirstClickFree::Concerns::Controller, type: :controller do
     context "first visit" do
       before { get :index, test: true }
       it { session[:first_click].should eq current_url }
+      it { request.env["first_click_free.url"].should eq current_url }
       it { response.should be_success }
     end
 
     context "subsequent visit to same page" do
       before { session[:first_click] = current_url }
+      it { get :index; request.env["first_click_free.url"].should eq current_url }
       it { expect { get :index }.not_to raise_error }
     end
 


### PR DESCRIPTION
@jarsbe,

This is an adjustment to the first click free gem to set the URL that first click free is active for in the `request.env` - I've done some reading and this seemed like the best place to put it, as it's part of the request's 'environment'.

Once this is merged, we can use this ability to set meta tags describing the current first click free URL, then hook into these tags with Javascript to allow or disallow link interactions.
